### PR TITLE
Make $wgIcalCaption available for line 108.

### DIFF
--- a/ical.php
+++ b/ical.php
@@ -69,7 +69,7 @@ function wfIcalGetEventDates($event) {
 // Execute 
 function wfIcalRender( $input, array $args, Parser $parser, PPFrame $frame ) {
   global $wgIcalTimeFormat, $wgIcalDateFormat, $wgIcalShortDateFormat,
-    $wgIcalDaysToShow, $wgOut, $wgIcalRefreshLink, $wgIcalIcsLink;
+    $wgIcalDaysToShow, $wgOut, $wgIcalRefreshLink, $wgIcalIcsLink,$wgIcalCaption;
 
   if(!empty($args["url"]))
     $config = array("url" => $args["url"]);


### PR DESCRIPTION
This fix prevents messages like "PHP Notice:  Undefined variable: wgIcalCaption in ical/ical.php on line 108" from appearing in webserver logs.